### PR TITLE
Small styling fixes for `Modal` component and `Playground` Page

### DIFF
--- a/src/app/playground/page.tsx
+++ b/src/app/playground/page.tsx
@@ -56,6 +56,8 @@ const Item: React.FC<IItemProps> = ({
             placeholder="blur"
             src={src}
             style={{
+              maxHeight: 1200,
+              maxWidth: 1200,
               objectFit: 'contain',
             }}
           />,

--- a/src/components/molecules/modal/modal.tsx
+++ b/src/components/molecules/modal/modal.tsx
@@ -38,10 +38,7 @@ export const Modal: React.FC<IModalProps> = ({ className = '', ...props }) => {
           >
             <div
               {...props}
-              className={`relative left-0 top-0 z-20 m-auto flex cursor-pointer items-center justify-center px-6 py-6 ${className}`}
-              onClick={() => {
-                setIsOpen(false)
-              }}
+              className={`relative left-0 top-0 z-20 m-auto flex items-center justify-center px-6 py-6 ${className}`}
             >
               <div className="h-full max-h-[1200px] w-full max-w-[1200px]">
                 {activeItem}
@@ -55,7 +52,12 @@ export const Modal: React.FC<IModalProps> = ({ className = '', ...props }) => {
               }}
             />
 
-            <div className="fixed cursor-pointer before:fixed before:bottom-0 before:right-4 before:top-0 before:h-full before:w-full before:bg-black-500/70 before:backdrop-blur-sm" />
+            <div
+              className="fixed cursor-pointer before:fixed before:bottom-0 before:right-4 before:top-0 before:h-full before:w-full before:bg-black-500/70 before:backdrop-blur-sm"
+              onClick={() => {
+                setIsOpen(false)
+              }}
+            />
           </m.div>
         )}
       </AnimatePresence>


### PR DESCRIPTION
- Ensured the modal items are restricted in `max-width` and `max-height`
- Ensured the user can close the modal when clicking on the backdrop